### PR TITLE
[FIX] Replace pnpm with nodejs/npm for rtlcss

### DIFF
--- a/images/odoo/Dockerfile
+++ b/images/odoo/Dockerfile
@@ -129,15 +129,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' > /et
     && rm -f /etc/apt/sources.list.d/pgdg.list \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pnpm
-RUN curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash bash -
-
-# Add pnpm to PATH
-ENV PNPM_HOME="/root/.local/share/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-
-# Install Node.js packages
-RUN pnpm install -g rtlcss
+# Install Node.js and rtlcss
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nodejs npm && \
+    npm install -g rtlcss && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install uv for Python package management
 COPY --from=ghcr.io/astral-sh/uv:0.7.21 /uv /uvx /bin/

--- a/images/odoo/Dockerfile
+++ b/images/odoo/Dockerfile
@@ -129,11 +129,15 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' > /et
     && rm -f /etc/apt/sources.list.d/pgdg.list \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js and rtlcss
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends nodejs npm && \
-    npm install -g rtlcss && \
-    rm -rf /var/lib/apt/lists/*
+# Install pnpm
+RUN curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash bash -
+
+# Add pnpm to PATH
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+# Install Node.js via pnpm and install rtlcss globally
+RUN pnpm env use --global lts && pnpm install -g rtlcss
 
 # Install uv for Python package management
 COPY --from=ghcr.io/astral-sh/uv:0.7.21 /uv /uvx /bin/


### PR DESCRIPTION
## Summary

- Fixes `rtlcss` not working at runtime by using `pnpm env use --global lts` to install Node.js via pnpm
- Keeps pnpm as the package manager (no switch to apt nodejs/npm)
- Node.js is now available in PATH at runtime, resolving both the missing runtime and the shim error

Fixes #63

## Test plan

- [ ] Build the image: `docker build -t odoo-test .`
- [ ] Run `docker exec <container> rtlcss --version` — should print version without errors
- [ ] Run `docker exec <container> node --version` — should print Node.js version
- [ ] Verify RTL CSS processing works in Odoo

🤖 Generated with [Claude Code](https://claude.com/claude-code)