### PR TITLE
feat(snippets): catch missing account info

### DIFF
--- a/snippets/mint_system.account.report_invoice_document.add_general_information.xml
+++ b/snippets/mint_system.account.report_invoice_document.add_general_information.xml
@@ -19,23 +19,29 @@
                     </div>
                     <div>
                         <t>
-                            <div t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].bank_id.name"/>
-                            <div>
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].bank_id.street"/>,
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].bank_id.country.code"/> -
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].bank_id.zip"/>
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].bank_id.city"/>
+                            <!-- Find the bank account with the correct currency -->
+                            <t t-set="bank_account" t-value="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0] if o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id) else None"/>
+                            <div t-if="bank_account">
+                                <div t-field="bank_account.bank_id.name"/>
+                                <div>
+                                    <t t-if="bank_account.bank_id.street"><span t-field="bank_account.bank_id.street"/>,</t>
+                                    <t t-if="bank_account.bank_id.country"><span t-field="bank_account.bank_id.country.code"/> - </t>
+                                    <span t-field="bank_account.bank_id.zip"/>
+                                    <span t-field="bank_account.bank_id.city"/>
+                                </div>
+                                <div>
+                                    <span>BIC / SWIFT:</span>
+                                    <span t-field="bank_account.bank_id.bic"/>
+                                </div>
+                                <span>(</span>
+                                <span t-field="bank_account.currency_id"/>
+                                <span>)</span>
+                                <span>IBAN:</span>
+                                <span t-field="bank_account.acc_number"/>
                             </div>
-                            <div>
-                            <span>BIC / SWIFT:</span>
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].bank_id.bic"/>
+                            <div t-if="not bank_account" style="color: red;">
+                                Bitte Kontodaten pflegen (Kontakte &gt; <span t-esc="o.company_id.name"/> &gt; Buchhaltung &gt; Bankkonten)
                             </div>
-                            <span>(</span>
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].currency_id"/>
-                            <span>)</span>
-                            <span>IBAN:</span>
-                            <span t-field="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0].acc_number"/>
-
                         </t>
                     </div>
                     <div>

--- a/snippets/mint_system.account.report_invoice_document.add_general_information.xml
+++ b/snippets/mint_system.account.report_invoice_document.add_general_information.xml
@@ -20,7 +20,7 @@
                     <div>
                         <t>
                             <!-- Find the bank account with the correct currency -->
-                            <t t-set="bank_account" t-value="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[0] if o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id) else None"/>
+                            <t t-set="bank_account" t-value="o.company_id.partner_id.bank_ids.filtered(lambda bank: bank.currency_id == o.currency_id)[:1]"/>
                             <div t-if="bank_account">
                                 <div t-field="bank_account.bank_id.name"/>
                                 <div>


### PR DESCRIPTION
If there is no bank account linked to the invoice's currency, a red warning is displayed in the report.
If the bank's address is not (completely) defined, according lines are not displayed anymore.
Links to OLE-100