### PR TITLE
feat(snippets): adaptation

### DIFF
--- a/snippets/mint_system.account.report_invoice_document.add_general_information.xml
+++ b/snippets/mint_system.account.report_invoice_document.add_general_information.xml
@@ -51,7 +51,7 @@
                             </div>
                             <div>
                             <span>UID:</span>
-                            <span t-field="o.company_id.partner_id.vat"/>
+                            <span t-field="o.company_id.partner_id.vat"/> VAT
                             </div>
                         </t>
                     </div>


### PR DESCRIPTION
VAT suffix shall be translateable (customer need). Therefore the suffix is taken out of ...partner_id.vat and put into the snippet's translations