### PR TITLE
feat(enterprise): support ssh transport for enterprise download

### DIFF
--- a/images/odoo/README.md
+++ b/images/odoo/README.md
@@ -252,7 +252,7 @@ Run the `download-odoo-enterprise` script to download the [Odoo Enterprise modul
 docker compose exec odoo download-odoo-enterprise
 ```
 
-This script downloads a tarball with `GITHUB_USERNAME` and `GITHUB_PAT`, or checks out a shallow git repo with `GIT_SSH_PRIVATE_KEY`. Set the transport with `ODOO_ENTERPRISE_TRANSPORT`, it defaults to `https` when a PAT is set and to `ssh` otherwise. The image has a pre-defined `ODOO_ENTERPRISE_REF` and `ODOO_ENTERPRISE_PATH`.
+This script downloads an archive with `GITHUB_USERNAME` and `GITHUB_PAT`. With a git url in `ODOO_ENTERPRISE_URL` it checks out a shallow git repo with `GIT_SSH_PRIVATE_KEY` instead. The image has a pre-defined `ODOO_ENTERPRISE_REF` and `ODOO_ENTERPRISE_PATH`.
 
 ### Init database
 
@@ -406,7 +406,7 @@ The image can clone git repositories.
 - `FORGEJO_PAT`: Forgejo access token for https git clone and archive download.
 - `ADDONS_GIT_REPOS`: Comma or line-break seperated list of git clone urls appended with `#` and branch name.
 - `ODOO_ENTERPRISE_REF`: Commit ref of Odoo Enterprise repo. Default is based on the image revision date.
-- `ODOO_ENTERPRISE_TRANSPORT`: Transport for the Odoo Enterprise download: `https` or `ssh`. Default is `https` when a GitHub PAT is set, else `ssh`.
+- `ODOO_ENTERPRISE_URL`: Url of the Odoo Enterprise repo. Default is `https://github.com/odoo/enterprise`. Use a git url like `git@github.com:odoo/enterprise` to download with SSH.
 
 You can use https and git urls for `ADDONS_GIT_REPOS`:
 

--- a/images/odoo/README.md
+++ b/images/odoo/README.md
@@ -252,7 +252,7 @@ Run the `download-odoo-enterprise` script to download the [Odoo Enterprise modul
 docker compose exec odoo download-odoo-enterprise
 ```
 
-This script requires `GITHUB_USERNAME` and `GITHUB_PAT`. The image has a pre-defined `ODOO_ENTERPRISE_REF` and `ODOO_ENTERPRISE_PATH`.
+This script downloads a tarball with `GITHUB_USERNAME` and `GITHUB_PAT`, or checks out a shallow git repo with `GIT_SSH_PRIVATE_KEY`. Set the transport with `ODOO_ENTERPRISE_TRANSPORT`, it defaults to `https` when a PAT is set and to `ssh` otherwise. The image has a pre-defined `ODOO_ENTERPRISE_REF` and `ODOO_ENTERPRISE_PATH`.
 
 ### Init database
 
@@ -406,6 +406,7 @@ The image can clone git repositories.
 - `FORGEJO_PAT`: Forgejo access token for https git clone and archive download.
 - `ADDONS_GIT_REPOS`: Comma or line-break seperated list of git clone urls appended with `#` and branch name.
 - `ODOO_ENTERPRISE_REF`: Commit ref of Odoo Enterprise repo. Default is based on the image revision date.
+- `ODOO_ENTERPRISE_TRANSPORT`: Transport for the Odoo Enterprise download: `https` or `ssh`. Default is `https` when a GitHub PAT is set, else `ssh`.
 
 You can use https and git urls for `ADDONS_GIT_REPOS`:
 

--- a/images/odoo/bin/download-odoo-enterprise
+++ b/images/odoo/bin/download-odoo-enterprise
@@ -1,13 +1,62 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ -z "$GITHUB_PAT" ]] || [[ -z "$GITHUB_USERNAME" ]]; then
-    log-entrypoint 'Error: GitHub personal access token or username is not set.'
-    exit 1
-fi
-
 odoo_enterprise_path="${ODOO_ENTERPRISE_PATH:="/var/lib/odoo/enterprise"}"
 ref_file="$odoo_enterprise_path/.last_ref"
+
+odoo_enterprise_transport="${ODOO_ENTERPRISE_TRANSPORT:=}"
+if [[ -z "$odoo_enterprise_transport" ]]; then
+    if [[ -n "$GITHUB_PAT" ]] && [[ -n "$GITHUB_USERNAME" ]]; then
+        odoo_enterprise_transport='https'
+    else
+        odoo_enterprise_transport='ssh'
+    fi
+fi
+
+case "$odoo_enterprise_transport" in
+    https)
+        if [[ -z "$GITHUB_PAT" ]] || [[ -z "$GITHUB_USERNAME" ]]; then
+            log-entrypoint 'Error: GitHub personal access token or username is not set.'
+            exit 1
+        fi
+        ;;
+    ssh)
+        ;;
+    *)
+        log-entrypoint "Error: unsupported ODOO_ENTERPRISE_TRANSPORT '$odoo_enterprise_transport' (expected 'https' or 'ssh')."
+        exit 1
+        ;;
+esac
+
+download_https() {
+    curl -fL -o "$odoo_enterprise_path/archive.tar.gz" \
+        "https://${GITHUB_USERNAME}:${GITHUB_PAT}@github.com/odoo/enterprise/archive/$ODOO_ENTERPRISE_REF.tar.gz"
+    tar -xzf "$odoo_enterprise_path/archive.tar.gz" --strip-components=1 -C "$odoo_enterprise_path"
+    rm "$odoo_enterprise_path/archive.tar.gz"
+}
+
+download_ssh() {
+    git_hostname='github.com'
+    git_url="git@${git_hostname}:odoo/enterprise.git"
+
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+    add-ssh-key
+    ssh-keyscan -t rsa,ed25519 "$git_hostname" > "$HOME/.ssh/known_hosts" 2>/dev/null
+
+    if [[ ! -d "$odoo_enterprise_path/.git" ]]; then
+        find "$odoo_enterprise_path" -mindepth 1 -maxdepth 1 ! -name '.last_ref' -exec rm -rf {} +
+
+        log-entrypoint "Init git repo ${git_url} in $odoo_enterprise_path."
+        git -C "$odoo_enterprise_path" init -q
+        git -C "$odoo_enterprise_path" remote add origin "$git_url"
+    fi
+
+    git -C "$odoo_enterprise_path" fetch -q --depth 1 origin "$ODOO_ENTERPRISE_REF"
+    git -C "$odoo_enterprise_path" checkout -q -f FETCH_HEAD
+
+    remove-ssh-key
+}
 
 mkdir -p "$odoo_enterprise_path"
 last_ref=""
@@ -16,11 +65,8 @@ if [[ -f "$ref_file" ]]; then
 fi
 
 if [[ -z "$last_ref" ]] || [[ "$last_ref" != "$ODOO_ENTERPRISE_REF" ]]; then
-    log-entrypoint "Downloading Odoo Enterprise $ODOO_ENTERPRISE_REF to ${odoo_enterprise_path}..."
-    curl -L -o "$odoo_enterprise_path/archive.tar.gz" \
-        "https://${GITHUB_USERNAME}:${GITHUB_PAT}@github.com/odoo/enterprise/archive/$ODOO_ENTERPRISE_REF.tar.gz"
-    tar -xzf "$odoo_enterprise_path/archive.tar.gz" --strip-components=1 -C "$odoo_enterprise_path"
-    rm "$odoo_enterprise_path/archive.tar.gz"
+    log-entrypoint "Downloading Odoo Enterprise $ODOO_ENTERPRISE_REF to ${odoo_enterprise_path} over ${odoo_enterprise_transport}..."
+    "download_$odoo_enterprise_transport"
     echo "$ODOO_ENTERPRISE_REF" > "$ref_file"
 else
     log-entrypoint "Odoo Enterprise $ODOO_ENTERPRISE_REF already downloaded. Skipping download."

--- a/images/odoo/bin/download-odoo-enterprise
+++ b/images/odoo/bin/download-odoo-enterprise
@@ -2,61 +2,12 @@
 set -e
 
 odoo_enterprise_path="${ODOO_ENTERPRISE_PATH:="/var/lib/odoo/enterprise"}"
+odoo_enterprise_url="${ODOO_ENTERPRISE_URL:="https://github.com/odoo/enterprise"}"
 ref_file="$odoo_enterprise_path/.last_ref"
 
-odoo_enterprise_transport="${ODOO_ENTERPRISE_TRANSPORT:=}"
-if [[ -z "$odoo_enterprise_transport" ]]; then
-    if [[ -n "$GITHUB_PAT" ]] && [[ -n "$GITHUB_USERNAME" ]]; then
-        odoo_enterprise_transport='https'
-    else
-        odoo_enterprise_transport='ssh'
-    fi
-fi
-
-case "$odoo_enterprise_transport" in
-    https)
-        if [[ -z "$GITHUB_PAT" ]] || [[ -z "$GITHUB_USERNAME" ]]; then
-            log-entrypoint 'Error: GitHub personal access token or username is not set.'
-            exit 1
-        fi
-        ;;
-    ssh)
-        ;;
-    *)
-        log-entrypoint "Error: unsupported ODOO_ENTERPRISE_TRANSPORT '$odoo_enterprise_transport' (expected 'https' or 'ssh')."
-        exit 1
-        ;;
-esac
-
-download_https() {
-    curl -fL -o "$odoo_enterprise_path/archive.tar.gz" \
-        "https://${GITHUB_USERNAME}:${GITHUB_PAT}@github.com/odoo/enterprise/archive/$ODOO_ENTERPRISE_REF.tar.gz"
-    tar -xzf "$odoo_enterprise_path/archive.tar.gz" --strip-components=1 -C "$odoo_enterprise_path"
-    rm "$odoo_enterprise_path/archive.tar.gz"
-}
-
-download_ssh() {
-    git_hostname='github.com'
-    git_url="git@${git_hostname}:odoo/enterprise.git"
-
-    mkdir -p "$HOME/.ssh"
-    chmod 700 "$HOME/.ssh"
-    add-ssh-key
-    ssh-keyscan -t rsa,ed25519 "$git_hostname" > "$HOME/.ssh/known_hosts" 2>/dev/null
-
-    if [[ ! -d "$odoo_enterprise_path/.git" ]]; then
-        find "$odoo_enterprise_path" -mindepth 1 -maxdepth 1 ! -name '.last_ref' -exec rm -rf {} +
-
-        log-entrypoint "Init git repo ${git_url} in $odoo_enterprise_path."
-        git -C "$odoo_enterprise_path" init -q
-        git -C "$odoo_enterprise_path" remote add origin "$git_url"
-    fi
-
-    git -C "$odoo_enterprise_path" fetch -q --depth 1 origin "$ODOO_ENTERPRISE_REF"
-    git -C "$odoo_enterprise_path" checkout -q -f FETCH_HEAD
-
-    remove-ssh-key
-}
+git_proto=$(parse-url "$odoo_enterprise_url" proto)
+git_hostname=$(parse-url "$odoo_enterprise_url" hostname)
+git_path=$(parse-url "$odoo_enterprise_url" path | sed 's/.git//g')
 
 mkdir -p "$odoo_enterprise_path"
 last_ref=""
@@ -65,8 +16,49 @@ if [[ -f "$ref_file" ]]; then
 fi
 
 if [[ -z "$last_ref" ]] || [[ "$last_ref" != "$ODOO_ENTERPRISE_REF" ]]; then
-    log-entrypoint "Downloading Odoo Enterprise $ODOO_ENTERPRISE_REF to ${odoo_enterprise_path} over ${odoo_enterprise_transport}..."
-    "download_$odoo_enterprise_transport"
+    log-entrypoint "Downloading Odoo Enterprise $ODOO_ENTERPRISE_REF to ${odoo_enterprise_path}..."
+
+    if [[ "$git_proto" = "https://" ]]; then
+
+        if [[ -z "$GITHUB_PAT" ]] || [[ -z "$GITHUB_USERNAME" ]]; then
+            log-entrypoint 'Error: GitHub personal access token or username is not set.'
+            exit 1
+        fi
+
+        curl -fL -o "$odoo_enterprise_path/archive.tar.gz" \
+            "${git_proto}${GITHUB_USERNAME}:${GITHUB_PAT}@${git_hostname}/${git_path}/archive/$ODOO_ENTERPRISE_REF.tar.gz"
+        tar -xzf "$odoo_enterprise_path/archive.tar.gz" --strip-components=1 -C "$odoo_enterprise_path"
+        rm "$odoo_enterprise_path/archive.tar.gz"
+
+    elif [[ "$git_proto" = "ssh://" ]]; then
+
+        mkdir -p "$HOME/.ssh"
+        chmod 700 "$HOME/.ssh"
+        add-ssh-key
+        ssh-keyscan -t rsa,ed25519 "$git_hostname" >> "$HOME/.ssh/known_hosts" 2>/dev/null
+
+        if [[ ! -d "$odoo_enterprise_path/.git" ]]; then
+
+            find "$odoo_enterprise_path" -mindepth 1 -maxdepth 1 ! -name '.last_ref' -exec rm -rf {} +
+
+            log-entrypoint "Init ${odoo_enterprise_url} in $odoo_enterprise_path."
+            git -C "$odoo_enterprise_path" init -q
+            git -C "$odoo_enterprise_path" remote add origin "$odoo_enterprise_url"
+        fi
+
+        log-entrypoint "Fetch $ODOO_ENTERPRISE_REF commit in $odoo_enterprise_path."
+        git -C "$odoo_enterprise_path" fetch --depth 1 origin "$ODOO_ENTERPRISE_REF"
+
+        log-entrypoint "Checkout $ODOO_ENTERPRISE_REF commit in $odoo_enterprise_path."
+        git -C "$odoo_enterprise_path" checkout -q -f "$ODOO_ENTERPRISE_REF"
+
+        remove-ssh-key
+
+    else
+        log-entrypoint "Error: unsupported protocol '${git_proto}' in ODOO_ENTERPRISE_URL."
+        exit 1
+    fi
+
     echo "$ODOO_ENTERPRISE_REF" > "$ref_file"
 else
     log-entrypoint "Odoo Enterprise $ODOO_ENTERPRISE_REF already downloaded. Skipping download."


### PR DESCRIPTION
The current version is missing a way to download odoo-enterprise with SSH, unlike clone-git-addons.
This is an issue because the approach using a PAT exposes a token that has read/write access.
It's not possible to use a fine-grained PAT because those are only available for owned repositories, which odoo/enterprise is not.