### PR TITLE
feat(ssh): move creation of ssh folders before ssh private key check

### DIFF
--- a/images/odoo/bin/add-ssh-key
+++ b/images/odoo/bin/add-ssh-key
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+
 if [[ -n "$GIT_SSH_PRIVATE_KEY" ]]; then
     key_filename="${SSH_ID_ALGORITHM:=id_ed25519}"
-    mkdir -p "$HOME/.ssh"
-    chmod 700 "$HOME/.ssh"
     log-entrypoint 'Add SSH key from env var.'
     decoded_git_ssh_private_key=$(echo -e "$GIT_SSH_PRIVATE_KEY" | base64 -d)
     echo "$decoded_git_ssh_private_key" > "$HOME/.ssh/$key_filename"


### PR DESCRIPTION
With the removal of the duplicated .ssh mkdir in one of the previous commits the behaviour also changed slightly.
The .ssh is now only created when a GIT_SSH_PRIVATE_KEY is provided.
In our dev setup we use mounts to mount the local .ssh into the image, so ssh works without providing a GIT_SSH_PRIVATE_KEY.
This change would restore the old behaviour which previously came from [clone-git-addons L21-L22](https://github.com/Mint-System/Odoo-Build/commit/f155ce281ebd664e2482bfd1ea53166a1fc87ab5#diff-feacbd471cbfa3e2af1b78c21d7dd52b9c47b5e6f3e09d4c32353a43ca6d93deL21-L22).