### PR TITLE
fix(enterprise): add -f flag to removal of ref file in ssh flow

### DIFF
--- a/images/odoo/bin/download-odoo-enterprise
+++ b/images/odoo/bin/download-odoo-enterprise
@@ -34,7 +34,7 @@ if [[ -z "$last_ref" ]] || [[ "$last_ref" != "$ODOO_ENTERPRISE_REF" ]]; then
 
         add-ssh-key
         ssh-keyscan -t rsa,ed25519 "$git_hostname" >> "$HOME/.ssh/known_hosts" 2>/dev/null
-        rm "$ref_file"
+        rm -f "$ref_file"
 
         if [[ ! -d "$odoo_enterprise_path/.git" ]]; then
             log-entrypoint "Init ${odoo_enterprise_url} in $odoo_enterprise_path."


### PR DESCRIPTION
The rm of the ref file in a previous commit introduced a bug where the ssh clone will always fail when run on a new container because the ref file will not exist. Since the script is ran with `set -e` the whole script will abort.
Adding the -f flag will prevent this error if the ref file does not exist yet.